### PR TITLE
Remove get/save method from Payload

### DIFF
--- a/minette/models/payload.py
+++ b/minette/models/payload.py
@@ -1,4 +1,3 @@
-import requests
 from ..serializer import Serializable
 
 
@@ -10,65 +9,33 @@ class Payload(Serializable):
     ----------
     content_type : str
         Content type of payload
+    content : Any
+        Content data
+    headers : dict
+        Headers of content or headers to get content
     url : str
         Url to get content
     thumb : str
         URL to get thumbnail image
-    headers : dict
-        HTTP Headers required for getting content
-    content : Any
-        Content itself
     """
-    def __init__(self, content_type="image", url=None, thumb=None,
-                 headers=None, content=None):
+    def __init__(self, *, content_type="image", content=None, headers=None,
+                 url=None, thumb=None,):
         """
         Parameters
         ----------
         content_type : str, default "image"
             Content type of payload
+        content : Any, default None
+            Content data
+        headers : dict, default None
+            Headers of content or headers to get content
         url : str, default None
             Url to get content
         thumb : str, default None
             URL to get thumbnail image
-        headers : dict, default None
-            HTTP Headers required for getting content
-        content : Any, default None
-            Content itself
         """
         self.content_type = content_type
+        self.content = content
+        self.headers = headers or {}
         self.url = url
         self.thumb = thumb if thumb is not None else url
-        self.headers = headers or {}
-        self.content = content
-
-    def get(self, set_content=False):
-        """
-        Get content data from url
-
-        Parameters
-        ----------
-        set_content : bool, default False
-            If True, set content data to content property
-
-        Returns
-        -------
-        content : Any
-            Content
-        """
-        data = requests.get(self.url, headers=self.headers, timeout=60).content
-        if set_content:
-            self.content = data
-        return data
-
-    def save(self, filepath):
-        """
-        Save content data to file
-
-        Parameters
-        ----------
-        filepath : str
-            File path to save content
-        """
-        data = self.get()
-        with open(filepath, "wb") as f:
-            f.write(data)

--- a/tests/models/test_payload.py
+++ b/tests/models/test_payload.py
@@ -10,14 +10,3 @@ def test_init():
     assert payload.thumb == "https://thumb"
     assert payload.headers == {}
     assert payload.content is None
-
-
-def test_get():
-    payload = Payload(content_type="image/jpeg", url="http://uezo.net/img/minette_architecture.png", thumb="https://thumb")
-    content = payload.get(set_content=True)
-    assert payload.content == content
-
-
-def test_save():
-    payload = Payload(content_type="image/jpeg", url="http://uezo.net/img/minette_architecture.png", thumb="https://thumb")
-    payload.save(filepath="payload.png")


### PR DESCRIPTION
Remove `requests` dependency. Model should not be dependent on specific http client library.