### PR TITLE
Enable to give shared objects to dialogs from main logic

### DIFF
--- a/minette/__init__.py
+++ b/minette/__init__.py
@@ -18,7 +18,8 @@ from .dialog import (
     DialogService,
     EchoDialogService,
     ErrorDialogService,
-    DialogRouter
+    DialogRouter,
+    DependencyContainer
 )
 from .models import *
 from .tagger import Tagger

--- a/minette/dialog/dependency.py
+++ b/minette/dialog/dependency.py
@@ -1,0 +1,14 @@
+""" Container class for components that DialogRouter/DialogServices depend """
+
+
+class DependencyContainer:
+    def __init__(self, dialog, dependency_rules=None, **defaults):
+        # set default dependencies
+        for k, v in defaults.items():
+            setattr(self, k, v)
+        # set dialog specific dependencies
+        if dependency_rules:
+            dialog_dependencies = dependency_rules.get(type(dialog))
+            if dialog_dependencies:
+                for k, v in dialog_dependencies.items():
+                    setattr(self, k, v)

--- a/minette/dialog/service.py
+++ b/minette/dialog/service.py
@@ -22,6 +22,8 @@ class DialogService:
         Timezone
     logger : logging.Logger
         Logger
+    dependencies : DependencyContainer
+        Container to attach objects DialogRouter depends
     """
 
     @classmethod
@@ -55,6 +57,7 @@ class DialogService:
         self.config = config
         self.timezone = timezone
         self.logger = logger or getLogger(__name__)
+        self.dependencies = None
 
     def execute(self, request, context, connection, performance):
         """

--- a/tests/dialog/test_dependency.py
+++ b/tests/dialog/test_dependency.py
@@ -1,0 +1,66 @@
+import sys
+import os
+sys.path.append(os.pardir)
+
+from minette.dialog import (
+    DialogService,
+    DialogRouter,
+    DependencyContainer
+)
+
+
+class SobaDialogService(DialogService):
+    pass
+
+
+class UdonDialogService(DialogService):
+    pass
+
+
+class RamenDialogService(DialogService):
+    pass
+
+
+class MenDialogRouter(DialogRouter):
+    pass
+
+
+def test_dependency():
+    # dependencies
+    d1 = 1
+    d2 = 2
+    d3 = 3
+    d4 = 4
+    d5 = 5
+    d6 = 6
+    d7 = 7
+
+    # define rules
+    dependency_rules = {
+        SobaDialogService: {"d1": d1, "d2": d2},
+        UdonDialogService: {"d2": d2, "d3": d3},
+        RamenDialogService: {"d3": d3, "d4": d4},
+        MenDialogRouter: {"d4": d4, "d5": d5}
+    }
+
+    # dialog service
+    soba_dep = DependencyContainer(SobaDialogService(), dependency_rules, d6=d6, d7=d7)
+    # dependencies for soba
+    assert soba_dep.d1 == 1
+    assert soba_dep.d2 == 2
+    # dependencies for all
+    assert soba_dep.d6 == 6
+    assert soba_dep.d7 == 7
+    # dependencies not for soba
+    assert hasattr(soba_dep, "d3") is False
+
+    # dialog router
+    men_dep = DependencyContainer(MenDialogRouter(), dependency_rules, d6=d6, d7=d7)
+    # dependencies for men
+    assert men_dep.d4 == 4
+    assert men_dep.d5 == 5
+    # dependencies for all
+    assert men_dep.d6 == 6
+    assert men_dep.d7 == 7
+    # dependencies not for men
+    assert hasattr(men_dep, "d1") is False


### PR DESCRIPTION
Main logic:

```python
# API Client shared with all dialogs
api = AwesomeAPI()

# create bot
bot = Minette()
# set shared object
bot.dialog_uses(apiclient=api)
```

Then, all DialogServices/DialogRouter can use `api` object as `apiclient`:

```python
self.dependencies.apiclient.get_awesome_info()
```

If you want to share objects with specific dialog:

```python
bot.dialog_uses(
    {
        FooDialog: {"onlyforfoo": onlyforfoo}
    }
    apiclient=api
)
```

Then, `onlyforfoo` is set only to `FooDialog` and `apiclient` is set to all.