### PR TITLE
Enable to set max length of text to parse morph to Taggers

### DIFF
--- a/minette/tagger/base.py
+++ b/minette/tagger/base.py
@@ -15,8 +15,10 @@ class Tagger:
     logger : logging.Logger
         Logger
     """
+    MAX_LENGTH = 1000
 
-    def __init__(self, config=None, timezone=None, logger=None, **kwargs):
+    def __init__(self, config=None, timezone=None, logger=None, *,
+                 max_length=MAX_LENGTH, **kwargs):
         """
         Parameters
         ----------
@@ -26,28 +28,26 @@ class Tagger:
             Timezone
         logger : Logger, default None
             Logger
+        max_length : int, default 1000
+            Max length of the text to parse
         """
         self.config = config
         self.timezone = timezone
         self.logger = logger or getLogger(__name__)
+        self.max_length = max_length
 
-    def parse(self, text):
-        """
-        Analyze and parse text
+    def validate(self, text, max_length=None):
+        if not text:
+            return False
+        elif max_length is not None:
+            if len(text) > max_length:
+                return False
+        elif len(text) > self.max_length:
+            return False
 
-        Parameters
-        ----------
-        text : str
-            Text to analyze
+        return True
 
-        Returns
-        -------
-        words : list of minette.WordNode (empty)
-            Word nodes
-        """
-        return []
-
-    def parse_as_generator(self, text):
+    def parse_as_generator(self, text, max_length=None):
         """
         Analyze and parse text, returns Generator
 
@@ -55,6 +55,8 @@ class Tagger:
         ----------
         text : str
             Text to analyze
+        max_length : int, default None
+            Max length of the text to parse
 
         Returns
         -------
@@ -62,3 +64,21 @@ class Tagger:
             Word nodes
         """
         yield from ()
+
+    def parse(self, text, max_length=None):
+        """
+        Analyze and parse text
+
+        Parameters
+        ----------
+        text : str
+            Text to analyze
+        max_length : int, default None
+            Max length of the text to parse
+
+        Returns
+        -------
+        words : list of minette.WordNode (empty)
+            Word nodes
+        """
+        return [wn for wn in self.parse_as_generator(text, max_length)]

--- a/minette/tagger/mecabtagger.py
+++ b/minette/tagger/mecabtagger.py
@@ -74,7 +74,7 @@ class MeCabTagger(Tagger):
         Logger
     """
 
-    def parse_as_generator(self, text):
+    def parse_as_generator(self, text, max_length=None):
         """
         Analyze and parse text using MeCab, returns Generator
 
@@ -82,15 +82,17 @@ class MeCabTagger(Tagger):
         ----------
         text : str
             Text to analyze
+        max_length : int, default 1000
+            Max length of the text to parse
 
         Returns
         -------
         words : list of minette.tagger.mecabtagger.MeCabNode
             MeCab word nodes
         """
-        ret = []
-        if not text:
-            return ret
+        if self.validate(text, max_length) is False:
+            return
+
         try:
             m = MeCab.Tagger("-Ochasen")
             # m.parse("") before m.parseToNode(text) against the bug that node.surface is not set
@@ -99,26 +101,9 @@ class MeCabTagger(Tagger):
             while node:
                 features = node.feature.split(",")
                 if features[0] != "BOS/EOS":
-                    # ret.append(MeCabNode.create(node.surface, features))
                     yield MeCabNode.create(node.surface, features)
                 node = node.next
         except Exception as ex:
             self.logger.error(
                 "MeCab parsing error: "
                 + str(ex) + "\n" + traceback.format_exc())
-
-    def parse(self, text):
-        """
-        Analyze and parse text
-
-        Parameters
-        ----------
-        text : str
-            Text to analyze
-
-        Returns
-        -------
-        words : list of minette.tagger.mecabtagger.MeCabNode
-            MeCab word nodes
-        """
-        return [mn for mn in self.parse_as_generator(text)]

--- a/tests/tagger/test_janometagger.py
+++ b/tests/tagger/test_janometagger.py
@@ -1,3 +1,6 @@
+import sys
+import os
+sys.path.append(os.pardir)
 import pytest
 from pytz import timezone
 from types import GeneratorType
@@ -70,6 +73,33 @@ def test_parse_as_generator():
         i += 1
 
 
+def test_parse_with_max():
+    tagger = JanomeTagger(max_length=8)
+    # over instance max_length
+    words_9 = tagger.parse("今日は良い天気です")
+    assert words_9 == []
+    # over instance max_length but under inline
+    words_9_max10 = tagger.parse("今日は良い天気です", max_length=10)
+    assert words_9_max10[0].surface == "今日"
+    # under instance max_length but over inline
+    words_9_max7 = tagger.parse("今日は良い天気", max_length=6)
+    assert words_9_max7 == []
+
+
+def test_parse_gen_with_max():
+    tagger = JanomeTagger(max_length=8)
+    # over instance max_length
+    words_9 = [w for w in tagger.parse_as_generator("今日は良い天気です")]
+    assert words_9 == []
+    # over instance max_length but under inline
+    words_9_max10 = [w for w in tagger.parse_as_generator("今日は良い天気です", max_length=10)]
+    assert words_9_max10[0].surface == "今日"
+    # under instance max_length but over inline
+    words_9_max7 = [w for w in tagger.parse_as_generator("今日は良い天気", max_length=6)]
+    assert words_9_max7 == []
+
+
 def test_error():
     tagger = JanomeTagger()
-    assert tagger.parse(object()) == []
+    with pytest.raises(TypeError):
+        tagger.parse(object())

--- a/tests/tagger/test_mecabtagger.py
+++ b/tests/tagger/test_mecabtagger.py
@@ -1,3 +1,6 @@
+import sys
+import os
+sys.path.append(os.pardir)
 import pytest
 from pytz import timezone
 from types import GeneratorType
@@ -70,6 +73,33 @@ def test_parse_as_generator():
         i += 1
 
 
+def test_parse_with_max():
+    tagger = MeCabTagger(max_length=8)
+    # over instance max_length
+    words_9 = tagger.parse("今日は良い天気です")
+    assert words_9 == []
+    # over instance max_length but under inline
+    words_9_max10 = tagger.parse("今日は良い天気です", max_length=10)
+    assert words_9_max10[0].surface == "今日"
+    # under instance max_length but over inline
+    words_9_max7 = tagger.parse("今日は良い天気", max_length=6)
+    assert words_9_max7 == []
+
+
+def test_parse_gen_with_max():
+    tagger = MeCabTagger(max_length=8)
+    # over instance max_length
+    words_9 = [w for w in tagger.parse_as_generator("今日は良い天気です")]
+    assert words_9 == []
+    # over instance max_length but under inline
+    words_9_max10 = [w for w in tagger.parse_as_generator("今日は良い天気です", max_length=10)]
+    assert words_9_max10[0].surface == "今日"
+    # under instance max_length but over inline
+    words_9_max7 = [w for w in tagger.parse_as_generator("今日は良い天気", max_length=6)]
+    assert words_9_max7 == []
+
+
 def test_error():
     tagger = MeCabTagger()
-    assert tagger.parse(object()) == []
+    with pytest.raises(TypeError):
+        tagger.parse(object())

--- a/tests/tagger/test_tagger_base.py
+++ b/tests/tagger/test_tagger_base.py
@@ -1,3 +1,6 @@
+import sys
+import os
+sys.path.append(os.pardir)
 import pytest
 from pytz import timezone
 from types import GeneratorType
@@ -18,3 +21,18 @@ def test_parse():
 def test_parse_as_generator():
     tagger = Tagger()
     assert isinstance(tagger.parse_as_generator("今日は良い天気です"), GeneratorType)
+
+
+def test_validate():
+    tagger = Tagger(max_length=5)
+    assert tagger.validate("こんにちは") is True
+    assert tagger.validate("ごきげんよう") is False
+    assert tagger.validate("こんにちは", max_length=4) is False
+    assert tagger.validate("ごきげんよう", max_length=6) is True
+    with pytest.raises(TypeError):
+        tagger.validate(object())
+    with pytest.raises(TypeError):
+        tagger.validate(1)
+
+    tagger_nomax = Tagger()
+    assert tagger_nomax.max_length == 1000


### PR DESCRIPTION
- `parse()` and `parse_as_generater()` is skipped when the given text is longer than max length.
- max length can be set both to instance and as argument.
- If text is longer than `tagger.length`, but equal or shorter than than the argument of `tagger.parse(text, max_length=???)`, then parse will run.

Also, change to raise error when the given text is not str. Previous version doesn't raise error but returns empty list or generator.