### PR TITLE
Add argument `tagger_max_length` to constructor of Minette

### DIFF
--- a/minette/core.py
+++ b/minette/core.py
@@ -67,7 +67,7 @@ class Minette:
                  user_store=None, user_table=None,
                  messagelog_store=None, messagelog_table=None,
                  default_dialog_service=None, dialog_router=None,
-                 tagger=None, prepare_table=True, **kwargs):
+                 tagger=None, tagger_max_length=None, prepare_table=True, **kwargs):
         """
         Parameters
         ----------
@@ -126,6 +126,8 @@ class Minette:
             and return proper DialogService for intent
         tagger: minette.Tagger or type, default None
             Morphological analysis engine
+        tagger_max_length: Max length of the text to parse morph, default None
+            Morphological analysis engine
         prepare_table: bool, default True
             Create tables for data stores if they don't exist.
         """
@@ -161,6 +163,7 @@ class Minette:
             "dialog_router": dialog_router,
             "default_dialog_service": default_dialog_service,
             "tagger": tagger,
+            "tagger_max_length": tagger_max_length,
         }
         setter_args.update({k: v for k, v in kwargs.items() if k not in setter_args})
 
@@ -263,10 +266,13 @@ class Minette:
             dr = dr(default_dialog_service=default_dialog_service, **kwargs)
         return dr
 
-    def _get_tagger(self, tagger, **kwargs):
+    def _get_tagger(self, tagger, tagger_max_length, **kwargs):
         tg = tagger or Tagger
         if issubclass(tg, Tagger):
-            tg = tg(**kwargs)
+            if tagger_max_length is not None:
+                tg = tg(max_length=tagger_max_length, **kwargs)
+            else:
+                tg = tg(**kwargs)
         return tg
 
     def chat(self, request):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ pytz==2020.1
 requests==2.24.0
 schedule==0.6.0
 pytest==6.0.1
+Janome==0.4.0


### PR DESCRIPTION
Given value will be set to `tagger.max_length`.
You can skip auto parsing by `tagger_max_length=0` and can parse morph manually by calling parse with value of length long enough.

For testing, Janome tagger is required.(Added to requirements-dev.txt)